### PR TITLE
Feature name fix: use WGPUFeatureName_DepthClipControl

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,10 +124,10 @@ $ bash ./build.sh -webgpu_native_examples
 
 ### Linux
 
-The build step described in the previous section creates a subfolder "x64" in the build folder. This subfolder contains all libraries and assets needed to run examples. Instead of a separate executable for each different example, a different approach was chosen to create an example launcher. This launcher can be used as follows, "./wgpu_sample_launcher <example_name>" where <example_name> is the filename of the example without the extension, like for example:
+The build step described in the previous section creates a subfolder "x64" in the build folder. This subfolder contains all libraries and assets needed to run examples. Instead of a separate executable for each different example, a different approach was chosen to create an example launcher. This launcher can be used as follows, "./wgpu_sample_launcher -s <example_name>" where <example_name> is the filename of the example without the extension, like for example:
 
 ```bash
-$ ./wgpu_sample_launcher shadertoy
+$ ./wgpu_sample_launcher -s shadertoy
 ```
 
 ## Project Layout

--- a/src/webgpu/context.c
+++ b/src/webgpu/context.c
@@ -95,7 +95,7 @@ void wgpu_create_device_and_queue(wgpu_context_t* wgpu_context)
     WGPUFeatureName_TextureCompressionETC2,
     WGPUFeatureName_TextureCompressionASTC,
     WGPUFeatureName_IndirectFirstInstance,
-    WGPUFeatureName_DepthClamping,
+    WGPUFeatureName_DepthClipControl,
     WGPUFeatureName_DawnShaderFloat16,
     WGPUFeatureName_DawnInternalUsages,
     WGPUFeatureName_DawnMultiPlanarFormats,


### PR DESCRIPTION
Feature Depth Clamp is removed in dawn. Require Depth Clip Control instead.
https://dawn.googlesource.com/dawn/+/8d73198aca5f1a83283068298c9bfd79640ca36b

This unblocks the build failure on my local linux machine. (with dawn header at f8c07d4753a32b62b52ba86e8ae0dba4830063b3)


Update Readme.md for the running examples cmd line as well (with -s now)