### PR TITLE
Fix compilation errors

### DIFF
--- a/lib/wgpu_native/wgpu_native.cpp
+++ b/lib/wgpu_native/wgpu_native.cpp
@@ -56,7 +56,8 @@ static void Initialize()
   gpuContext.dawn_native.procTable = dawn::native::GetProcs();
   dawnProcSetProcs(&gpuContext.dawn_native.procTable);
   gpuContext.dawn_native.instance = std::make_unique<dawn::native::Instance>();
-  gpuContext.dawn_native.instance->DiscoverDefaultAdapters();
+  // Discovers adapters
+  (void)gpuContext.dawn_native.instance->EnumerateAdapters();
   gpuContext.dawn_native.instance->EnableBackendValidation(true);
   gpuContext.dawn_native.instance->SetBackendValidationLevel(
     dawn::native::BackendValidationLevel::Full);

--- a/src/webgpu/context.c
+++ b/src/webgpu/context.c
@@ -89,7 +89,6 @@ void wgpu_create_device_and_queue(wgpu_context_t* wgpu_context)
   static const WGPUFeatureName feature_names[WGPU_FEATURE_COUNT] = {
     WGPUFeatureName_Depth32FloatStencil8,
     WGPUFeatureName_TimestampQuery,
-    WGPUFeatureName_PipelineStatisticsQuery,
     WGPUFeatureName_TextureCompressionBC,
     WGPUFeatureName_TextureCompressionETC2,
     WGPUFeatureName_TextureCompressionASTC,


### PR DESCRIPTION
Following the build instructions from the readme I got these two errors:
- `dawn::native::DiscoverDefaultAdapters` doesn't exist
- `WGPUFeatureName_PipelineStatisticsQuery` doesn't exist

Maybe I'm pulling a wrong version of Dawn?